### PR TITLE
Creacion confirm dialog

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -112,6 +112,7 @@
         "rxjs": "^7.8.0",
         "semver": "^7.3.8",
         "superstruct": "^1.0.3",
+        "sweetalert2": "^11.7.27",
         "tinycolor2": "^1.6.0",
         "url-join": "^5.0.0",
         "use-react-router-breadcrumbs": "^4.0.1",
@@ -47154,6 +47155,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/sweetalert2": {
+      "version": "11.7.27",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.27.tgz",
+      "integrity": "sha512-QbRXGQn1sb7HEhzA/K2xtWIwQHh/qkSbb1w6jYcTql2xy17876lTREEt1D4X6Q0x2wHtfUjKJ+Cb8IVkRoq7DQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.0.1",
       "license": "MIT"
@@ -80586,6 +80596,11 @@
           "dev": true
         }
       }
+    },
+    "sweetalert2": {
+      "version": "11.7.27",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.27.tgz",
+      "integrity": "sha512-QbRXGQn1sb7HEhzA/K2xtWIwQHh/qkSbb1w6jYcTql2xy17876lTREEt1D4X6Q0x2wHtfUjKJ+Cb8IVkRoq7DQ=="
     },
     "tabbable": {
       "version": "6.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -107,6 +107,7 @@
     "rxjs": "^7.8.0",
     "semver": "^7.3.8",
     "superstruct": "^1.0.3",
+    "sweetalert2": "^11.7.27",
     "tinycolor2": "^1.6.0",
     "url-join": "^5.0.0",
     "use-react-router-breadcrumbs": "^4.0.1",

--- a/frontend/src/Editor/Inspector/Utils.js
+++ b/frontend/src/Editor/Inspector/Utils.js
@@ -39,7 +39,8 @@ export function renderElement(
   if (
     componentConfig.component == 'DropDown' ||
     componentConfig.component == 'Form' ||
-    componentConfig.component == 'Listview'
+    componentConfig.component == 'Listview' ||
+    componentConfig.component == 'ConfirmDialog'
   ) {
     const paramTypeConfig = componentMeta[paramType] || {};
     const paramConfig = paramTypeConfig[param] || {};

--- a/frontend/src/Editor/MUIComponents/ConfirmDialog.jsx
+++ b/frontend/src/Editor/MUIComponents/ConfirmDialog.jsx
@@ -1,0 +1,64 @@
+import { Button } from '@mui/material';
+import React from 'react';
+import Swal from 'sweetalert2';
+export const ConfirmDialog = (props) => {
+  //   const { title, description, icon, buttons } = props;
+  const { height, properties, styles, fireEvent, registerAction, id, dataCy, setExposedVariable } = props;
+  const {
+    backgroundColor,
+    textColor,
+    borderRadius,
+    disabledState,
+    visibility,
+    confirmColor,
+    denyColor,
+    cancelColor,
+    boxShadow,
+  } = styles;
+  const { label, icon, title, description, denyButton, cancelButton, confirmText, denyText, cancelText } = properties;
+
+  const showAlert = () => {
+    Swal.fire({
+      title,
+      text: description,
+      icon,
+      showDenyButton: denyButton,
+      showCancelButton: cancelButton,
+      confirmButtonText: confirmText,
+      denyButtonText: denyText,
+      cancelButtonText: cancelText,
+      confirmButtonColor: confirmColor,
+      denyButtonColor: denyColor,
+      cancelButtonColor: cancelColor,
+      target: document.getElementsByClassName('canvas-area')[0],
+    }).then((result) => {
+      if (result.isConfirmed) {
+        // Logica de confirmacion.
+      } else if (result.isDenied) {
+        // Logica de cancelar
+      }
+    });
+  };
+
+  return (
+    <>
+      {visibility ? (
+        <Button
+          variant="contained"
+          disabled={disabledState}
+          onClick={showAlert}
+          sx={{
+            color: textColor,
+            backgroundColor: backgroundColor,
+            borderRadius: borderRadius,
+            width: '100%',
+            height,
+            boxShadow,
+          }}
+        >
+          {label}
+        </Button>
+      ) : null}
+    </>
+  );
+};

--- a/frontend/src/Editor/MUIComponents/ConfirmDialog.jsx
+++ b/frontend/src/Editor/MUIComponents/ConfirmDialog.jsx
@@ -33,9 +33,9 @@ export const ConfirmDialog = (props) => {
       target: document.getElementsByClassName('canvas-area')[0],
     }).then((result) => {
       if (result.isConfirmed) {
-        // Logica de confirmacion.
+        // Lógica de confirmación.
       } else if (result.isDenied) {
-        // Logica de cancelar
+        // Lógica de cancelar
       }
     });
   };

--- a/frontend/src/Editor/MUIComponents/index.js
+++ b/frontend/src/Editor/MUIComponents/index.js
@@ -51,6 +51,7 @@ import { Map } from '../Components/Map/Map';
 import { QrScanner } from '../Components/QrScanner/QrScanner';
 import { StarRating } from './StarRating';
 import { Table } from './Table/Table';
+import { ConfirmDialog } from './ConfirmDialog';
 
 const MUIComponents = {
   Button,
@@ -106,6 +107,7 @@ const MUIComponents = {
   IconButton,
   Form,
   BoundedBox,
+  ConfirmDialog,
 };
 
 export default MUIComponents;

--- a/frontend/src/Editor/WidgetManager/customWidgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/customWidgetConfig.js
@@ -160,4 +160,205 @@ export const customWidgets = [
       },
     },
   },
+  {
+    name: 'ConfirmDialog',
+    displayName: 'ConfirmDialog',
+    description: 'Trigger actions:  alerts ',
+    component: 'ConfirmDialog',
+    defaultSize: {
+      width: 3,
+      height: 30,
+    },
+    others: {
+      showOnDesktop: { type: 'toggle', displayName: 'Show on desktop' },
+      showOnMobile: { type: 'toggle', displayName: 'Show on mobile' },
+    },
+    properties: {
+      label: {
+        type: 'code',
+        displayName: 'Label Button',
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+      title: {
+        type: 'code',
+        displayName: 'Title Dialog',
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+      description: {
+        type: 'code',
+        displayName: 'Description Dialog',
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+      icon: {
+        type: 'select',
+        displayName: 'Icon Info',
+        options: [
+          { name: 'Success', value: 'success' },
+          { name: 'Error', value: 'error' },
+          { name: 'Information', value: 'info' },
+          { name: 'Warning', value: 'warning' },
+          { name: 'Question', value: 'question' },
+        ],
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+      confirmText: {
+        type: 'code',
+        displayName: 'Botton Confirm Text',
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+      denyButton: {
+        type: 'toggle',
+        displayName: 'Show Deny Button',
+        validation: {
+          schema: { type: 'boolean' },
+        },
+      },
+      denyText: {
+        type: 'code',
+        displayName: 'Botton Confirm Text',
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+      cancelButton: {
+        type: 'toggle',
+        displayName: 'Show Cancel Button',
+        validation: {
+          schema: { type: 'boolean' },
+        },
+      },
+      cancelText: {
+        type: 'code',
+        displayName: 'Botton Confirm Text',
+        validation: {
+          schema: { type: 'string' },
+        },
+      },
+    },
+    events: {
+      onClick: { displayName: 'On click' },
+      onHover: { displayName: 'On hover' },
+    },
+    styles: {
+      backgroundColor: {
+        type: 'color',
+        displayName: 'Background color Button',
+        validation: {
+          schema: { type: 'string' },
+          defaultValue: false,
+        },
+      },
+      textColor: {
+        type: 'color',
+        displayName: 'Text color Button',
+        validation: {
+          schema: { type: 'string' },
+          defaultValue: false,
+        },
+      },
+      confirmColor: {
+        type: 'color',
+        displayName: 'Text color Button Confirm',
+        validation: {
+          schema: { type: 'string' },
+          defaultValue: false,
+        },
+      },
+      denyColor: {
+        type: 'color',
+        displayName: 'Text color Button Deny',
+        validation: {
+          schema: { type: 'string' },
+          defaultValue: false,
+        },
+      },
+      cancelColor: {
+        type: 'color',
+        displayName: 'Text color Button Cancel',
+        validation: {
+          schema: { type: 'string' },
+          defaultValue: false,
+        },
+      },
+      visibility: {
+        type: 'toggle',
+        displayName: 'Visibility',
+        validation: {
+          schema: { type: 'boolean' },
+          defaultValue: false,
+        },
+      },
+      disabledState: {
+        type: 'toggle',
+        displayName: 'Disable',
+        validation: {
+          schema: { type: 'boolean' },
+          defaultValue: false,
+        },
+      },
+      borderRadius: {
+        type: 'number',
+        displayName: 'Border radius',
+        validation: {
+          schema: { type: 'number' },
+          defaultValue: false,
+        },
+      },
+    },
+    exposedVariables: {
+      buttonText: 'Button',
+    },
+    actions: [
+      {
+        handle: 'click',
+        displayName: 'Click',
+      },
+      {
+        handle: 'disable',
+        displayName: 'Disable',
+        params: [{ handle: 'disable', displayName: 'Value', defaultValue: `{{false}}`, type: 'toggle' }],
+      },
+      {
+        handle: 'visibility',
+        displayName: 'Visibility',
+        params: [{ handle: 'visible', displayName: 'Value', defaultValue: `{{false}}`, type: 'toggle' }],
+      },
+    ],
+    definition: {
+      others: {
+        showOnDesktop: { value: '{{true}}' },
+        showOnMobile: { value: '{{false}}' },
+      },
+      properties: {
+        label: { value: 'Open' },
+        title: { value: `Title display` },
+        description: { value: 'Description display' },
+        icon: { value: 'error' },
+        denyButton: { value: true },
+        cancelButton: { value: false },
+        cancelText: { value: 'Cancelar' },
+        denyText: { value: 'No Guardar' },
+        confirmText: { value: 'Guardar' },
+      },
+      events: [],
+      styles: {
+        backgroundColor: { value: '#375FCF' },
+        textColor: { value: '#fff' },
+        visibility: { value: '{{true}}' },
+        borderRadius: { value: '{{0}}' },
+        borderColor: { value: '#375FCF' },
+        disabledState: { value: '{{false}}' },
+      },
+    },
+  },
 ];

--- a/frontend/src/Editor/WidgetManager/customWidgetConfig.js
+++ b/frontend/src/Editor/WidgetManager/customWidgetConfig.js
@@ -211,7 +211,7 @@ export const customWidgets = [
       },
       confirmText: {
         type: 'code',
-        displayName: 'Botton Confirm Text',
+        displayName: 'Button Confirm Text',
         validation: {
           schema: { type: 'string' },
         },
@@ -225,7 +225,11 @@ export const customWidgets = [
       },
       denyText: {
         type: 'code',
-        displayName: 'Botton Confirm Text',
+        displayName: 'Button Deny Text',
+        conditionallyRender: {
+          key: 'denyButton',
+          value: true,
+        },
         validation: {
           schema: { type: 'string' },
         },
@@ -239,7 +243,11 @@ export const customWidgets = [
       },
       cancelText: {
         type: 'code',
-        displayName: 'Botton Confirm Text',
+        displayName: 'Button Cancel Text',
+        conditionallyRender: {
+          key: 'cancelButton',
+          value: true,
+        },
         validation: {
           schema: { type: 'string' },
         },


### PR DESCRIPTION
Se crea nuevo componente de confirm dialog en el cual se puede;
- elegir entre 1 a 3 botones de acción editables tanto en texto como color
- Elegir el titulo y descripción del modal 
- Elegir si será un modal de Success,Error,Information,Warning,Question

utilizando la libreria de SweetAlert2
![image](https://github.com/synchroxdev/tooljet-ui/assets/124922587/fb5a02de-1b87-492c-a1fc-0d02e8e397e3)
